### PR TITLE
Add python_requires to avoid breaking unpinned Python 2 installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setuptools.setup(
     platforms=['POSIX', 'Windows'],
     packages=['feedparser', 'feedparser.datetimes', 'feedparser.namespaces', 'feedparser.parsers'],
     install_requires=['sgmllib3k'],
+    python_requires='>=3.6', 
     keywords=['atom', 'cdf', 'feed', 'parser', 'rdf', 'rss'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
The current 6.0.0 version, which is stated to be Python 3 only, actually gets into Python 2 installations because of a missing `python_requires` update. This PR specifies supporting Python 3.6 and above explicitly. 